### PR TITLE
Adjust number of average blocks since the round length is 32.768s now

### DIFF
--- a/status.py
+++ b/status.py
@@ -1669,7 +1669,7 @@ def casper_block_info():
     block_info.addstr(index, 2, 'Next Upgrade : ', curses.color_pair(1))
     block_info.addstr('{}'.format(next_upgrade), curses.color_pair(4 if next_upgrade == None else 5))
 
-    avg_num_blocks = 110
+    avg_num_blocks = 220
     block_percent = 1
     number_blocks = 0
 


### PR DESCRIPTION
I think 220 should be fine since the progress bar has a precision of 34 bars only. Currently the progress bar is at 100% already after 110 blocks.

Time based version to estimate the current era based on the number of blocks of the previous era:
https://github.com/sacherjj/casper-network-monitor/blob/clean-up-refactor/app/cnm/data/abstract_era_times.py

Explanation from the author:
--- START ---
I schedule a task to run 2 hours and 5 minutes after the last to get the latest time and walk them forward as estimates.  So a simple time of first block of current Era plus 2 hours and 9 seconds is the expected time of next era.
--- END ---